### PR TITLE
fix: Make Media SDK player work in Safari and iOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@cere/media-sdk-react": "^1.4.2-rc.10",
+        "@cere/media-sdk-react": "^1.4.2-rc.11",
         "@telegram-apps/sdk-react": "^1.1.3",
         "@ton/core": "^0.56.3",
         "@tonconnect/ui-react": "^2.0.6"
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/@cere/media-sdk-client": {
-      "version": "1.4.2-rc.10",
-      "resolved": "https://registry.npmjs.org/@cere/media-sdk-client/-/media-sdk-client-1.4.2-rc.10.tgz",
-      "integrity": "sha512-KtMORV2OZwA/uEJuNe771vAJ1iUV6HPVeJ6GFpTcC+73aWRLnP8KsNAejzPfWD8S6adxQ0syOLwMnm/9qlmQEw==",
+      "version": "1.4.2-rc.11",
+      "resolved": "https://registry.npmjs.org/@cere/media-sdk-client/-/media-sdk-client-1.4.2-rc.11.tgz",
+      "integrity": "sha512-zuIePCPgF1O8EVYBtr7fDb1SyHl5sQdoEkxgQMNgzCZCmm/dDhYs4OFc1kdm5yBCaVg4/dl0gs3uESuKn0XYyQ==",
       "dependencies": {
         "axios": "^1.6.5",
         "ethers": "^5.7.2",
@@ -456,11 +456,11 @@
       }
     },
     "node_modules/@cere/media-sdk-react": {
-      "version": "1.4.2-rc.10",
-      "resolved": "https://registry.npmjs.org/@cere/media-sdk-react/-/media-sdk-react-1.4.2-rc.10.tgz",
-      "integrity": "sha512-JPhAYtqLLvxceXdXYDkqwWqY9XFlE8H7+nw558qzYSts4/PRgk/2RFuWwh1MqeQoXdJ+U3nXGFMXJG+CgXE/6A==",
+      "version": "1.4.2-rc.11",
+      "resolved": "https://registry.npmjs.org/@cere/media-sdk-react/-/media-sdk-react-1.4.2-rc.11.tgz",
+      "integrity": "sha512-7kJBs9tgm3OfjLMnkivUhVwB3/ZeOTDnIhrUkFU5o/rBJQfxfBCUSUmv7VIIey28frTdejYaQaJ7TUEw6owpUw==",
       "dependencies": {
-        "@cere/media-sdk-client": "1.4.2-rc.10",
+        "@cere/media-sdk-client": "1.4.2-rc.11",
         "blakejs": "^1.2.1",
         "clsx": "^2.1.0",
         "ethers": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@cere/media-sdk-react": "^1.4.2-rc.10",
+    "@cere/media-sdk-react": "^1.4.2-rc.11",
     "@telegram-apps/sdk-react": "^1.1.3",
     "@ton/core": "^0.56.3",
     "@tonconnect/ui-react": "^2.0.6"

--- a/src/components/VideoPlayer/VideoPlayer.css
+++ b/src/components/VideoPlayer/VideoPlayer.css
@@ -1,0 +1,15 @@
+/**
+* Import the styles for the VideoPlayer component from the media-sdk-react package.
+* This is the CSS file that will be used to style the VideoPlayer component.
+
+* TODO: Properly import by package name - not by file path.
+*/
+@import '../../../node_modules/@cere/media-sdk-react/dist/browser.css';
+
+.VideoPlayer-card {
+  border-radius: 0;
+}
+
+.VideoPlayer-card .loading-container {
+  background-color: transparent;
+}

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -1,15 +1,9 @@
 import { Card, Modal, ModalProps } from '@tg-app/ui';
 import { Video } from '@tg-app/api';
-// import { IosVideoPlayer as CerePlayer } from '@cere/media-sdk-react';
+import { VideoPlayer as CerePlayer } from '@cere/media-sdk-react';
 import { useViewport } from '@telegram-apps/sdk-react';
 
-/**
-* Import the styles for the VideoPlayer component from the media-sdk-react package.
-* This is the CSS file that will be used to style the VideoPlayer component.
-
-* TODO: Properly import by package name - not by file path.
-*/
-import '../../../node_modules/@cere/media-sdk-react/dist/browser.css';
+import './VideoPlayer.css';
 
 export type VideoPlayerProps = Pick<ModalProps, 'open'> & {
   video?: Video;
@@ -41,21 +35,18 @@ export const VideoPlayer = ({ token, video, open = false, onClose }: VideoPlayer
     <Modal open={open && !!video && !!token} onOpenChange={(open) => !open && onClose?.()}>
       <Modal.Header>{video?.name}</Modal.Header>
 
-      <Card style={{ borderRadius: 0 }}>
+      <Card className="VideoPlayer-card">
         {url && (
-          <video autoPlay controls height={height} width={width}>
-            <source src={url!} type={video?.mimeType} />
-          </video>
-
-          // <CerePlayer
-          //   hlsEnabled={false}
-          //   src={url!}
-          //   type={video?.mimeType}
-          //   loadingComponent={<div />}
-          //   videoOverrides={{
-          //     autoPlay: true,
-          //   }}
-          // />
+          <CerePlayer
+            hlsEnabled={false}
+            src={url!}
+            type={video?.mimeType}
+            loadingComponent={<div />}
+            videoOverrides={{
+              autoPlay: true,
+              style: `width: ${width}px; height: ${height}px;` as any,
+            }}
+          />
         )}
 
         <Card.Cell readOnly subtitle={video?.description} style={{ paddingBottom: 16 }}>


### PR DESCRIPTION
In order to make video work in Safari and iOS the video type should be provided either by the server (DDC Node) or manually.