### PR TITLE
Add source to video URL to track traffic

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -22,6 +22,8 @@ const createUrl = (video?: Video, token?: string) => {
     url.searchParams.set('token', token);
   }
 
+  url.searchParams.set('source', 'telegram');
+
   return url.href;
 };
 


### PR DESCRIPTION
This 'source' is needed to split a traffic on dashboards  (logged by nginx, send to loki and used in grafana)